### PR TITLE
Fix deprecation warning for is_literal_type.

### DIFF
--- a/strong_typedef.hpp
+++ b/strong_typedef.hpp
@@ -216,7 +216,7 @@ namespace jss {
     template <typename Other> struct mixed_##name {                            \
         template <                                                             \
             typename Derived, typename ValueType,                              \
-            bool= std::is_integral<ValueType>::value>                          \
+            bool= std::is_arithmetic<ValueType>::value>                        \
         struct mixin {                                                         \
             friend constexpr Derived                                           \
             operator op_symbol(Derived const &lhs, Other const &rhs) noexcept( \
@@ -286,7 +286,7 @@ namespace jss {
     struct self_##name {                                                       \
         template <                                                             \
             typename Derived, typename ValueType,                              \
-            bool= std::is_integral<ValueType>::value>                          \
+            bool= std::is_arithmetic<ValueType>::value>                        \
         struct mixin {                                                         \
             friend constexpr Derived operator op_symbol(                       \
                 Derived const &lhs,                                            \

--- a/strong_typedef.hpp
+++ b/strong_typedef.hpp
@@ -216,7 +216,7 @@ namespace jss {
     template <typename Other> struct mixed_##name {                            \
         template <                                                             \
             typename Derived, typename ValueType,                              \
-            bool= std::is_literal_type<ValueType>::value>                      \
+            bool= std::is_integral<ValueType>::value>                          \
         struct mixin {                                                         \
             friend constexpr Derived                                           \
             operator op_symbol(Derived const &lhs, Other const &rhs) noexcept( \
@@ -286,7 +286,7 @@ namespace jss {
     struct self_##name {                                                       \
         template <                                                             \
             typename Derived, typename ValueType,                              \
-            bool= std::is_literal_type<ValueType>::value>                      \
+            bool= std::is_integral<ValueType>::value>                          \
         struct mixin {                                                         \
             friend constexpr Derived operator op_symbol(                       \
                 Derived const &lhs,                                            \
@@ -624,7 +624,7 @@ namespace jss {
         struct bitwise_not {
             template <
                 typename Derived, typename ValueType,
-                bool= std::is_literal_type<ValueType>::value>
+                bool= std::is_integral<ValueType>::value>
             struct mixin {
                 friend constexpr Derived operator~(Derived const &lhs) noexcept(
                     noexcept(~std::declval<ValueType const &>())) {
@@ -645,7 +645,7 @@ namespace jss {
         template <typename Other> struct bitwise_left_shift {
             template <
                 typename Derived, typename ValueType,
-                bool= std::is_literal_type<ValueType>::value>
+                bool= std::is_integral<ValueType>::value>
             struct mixin {
                 friend constexpr Derived
                 operator<<(Derived const &lhs, Other const &rhs) noexcept(
@@ -687,7 +687,7 @@ namespace jss {
         template <typename Other> struct bitwise_right_shift {
             template <
                 typename Derived, typename ValueType,
-                bool= std::is_literal_type<ValueType>::value>
+                bool= std::is_integral<ValueType>::value>
             struct mixin {
                 friend constexpr Derived
                 operator>>(Derived const &lhs, Other const &rhs) noexcept(

--- a/test_strong_typedef.cpp
+++ b/test_strong_typedef.cpp
@@ -1817,6 +1817,20 @@ void test_adding_two_strong_typedefs() {
     static_assert(st3.underlying_value() == 69);
     static_assert(st4.underlying_value() == 69);
 
+    using STD1= jss::strong_typedef<struct tag1, double>;
+    using STD2= jss::strong_typedef<
+        struct tag2, double, jss::strong_typedef_properties::mixed_addable<STD1>>;
+
+    constexpr STD1 std1(23.4);
+    constexpr STD2 std2(45.6);
+
+    constexpr STD2 std3= std2 + std1;
+    constexpr STD2 std4= std1 + std2;
+
+    static_assert(std3.underlying_value() == 69.0);
+    static_assert(std4.underlying_value() == 69.0);
+
+
     using STS1= jss::strong_typedef<struct tag1, std::string>;
     using STS2= jss::strong_typedef<
         struct tag2, std::string,


### PR DESCRIPTION
This patch removes the deprecation warning with C++17 parser. 

Use is_integral for bit operations and is_arithmetic for binary operators.